### PR TITLE
fix: beforechangetab validate when press clicked in active tab

### DIFF
--- a/src/components/TabsPanel/TabsPanel.tsx
+++ b/src/components/TabsPanel/TabsPanel.tsx
@@ -51,7 +51,7 @@ export const VTabsPanel = (props: ITabsPanelProps) => {
   };
 
   const handleChangeTab = (key: string) => {
-    if (props.beforeChangeTabValidation) {
+    if (props.beforeChangeTabValidation && state.active !== key) {
       toggleIsOpenDialogOpen();
       setState({ ...state, possibleKey: key });
     } else {


### PR DESCRIPTION
fix: beforechangetab validate when press clicked in active tab