### PR TITLE
fix(vsearchselectfieldasync): fix needed when empty value

### DIFF
--- a/src/components/Form/Inputs/SearchSelectAsync/hook/useSearchSelectFieldAsync.ts
+++ b/src/components/Form/Inputs/SearchSelectAsync/hook/useSearchSelectFieldAsync.ts
@@ -90,6 +90,7 @@ export const useSearchSelectFieldAsync = ({
       }
       return;
     }
+    onClearComponent();
   };
 
   const getValueFirstLoad = () => {


### PR DESCRIPTION
clean options when search value in hook is null